### PR TITLE
Issue #6 - Configure Git with information from the host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.env
 .vagrant/
 ubuntu-xenial-16.04-cloudimg-console.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Docker and Docker Compose. The Vagrant user is added to the Docker group.
-- Latest Python 3 and Python 3 Pip.
+- Python 3 and Python 3 Pip.
+- Git configuration using information and an SSH key from the host.
 
 ## [1.0.0] - 2018-07-13
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,8 +31,14 @@ Vagrant.configure("2") do |config|
       shell.env = {
         "VAGRANT_VM_NAME" => vagrant_vm_name,
         "VAGRANT_USER" => vagrant_vm_user,
-        "VAGRANT_USER_GROUP" => vagrant_vm_user_group
+        "VAGRANT_USER_GROUP" => vagrant_vm_user_group,
+        "GIT_USER_NAME" => ENV["GIT_USER_NAME"],
+        "GIT_USER_EMAIL" => ENV["GIT_USER_EMAIL"]
       }
+
+      git_ssh_private_key = ""
+      File.foreach(ENV["GIT_SSH_PRIVATE_KEY_FILE"]) {|line|git_ssh_private_key << line}
+      shell.env["GIT_SSH_PRIVATE_KEY"] = Base64.strict_encode64(git_ssh_private_key)
     end
   end
 end

--- a/bin/synced-folder-exclude
+++ b/bin/synced-folder-exclude
@@ -1,3 +1,4 @@
+.env
 .git/
 .gitignore
 .vagrant/

--- a/provisioning/ansible/ansible-playbook.yaml
+++ b/provisioning/ansible/ansible-playbook.yaml
@@ -1,11 +1,13 @@
 ---
 - hosts: self
   vars_files:
+  - /etc/provisioning/git-vars.yaml
   - /etc/provisioning/vagrant-vars.yaml
   roles:
   - role: git
   - role: bash-environment
   - role: ansible-environment
+  - role: git-environment
   - role: vagrant-environment
   - role: docker
     vars:

--- a/provisioning/ansible/roles/git-environment/files/.bashrc.d/git-vars.sh
+++ b/provisioning/ansible/roles/git-environment/files/.bashrc.d/git-vars.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Keep this script idempotent. It will probably be called multiple times.
+
+source /etc/provisioning/git-vars.sh

--- a/provisioning/ansible/roles/git-environment/meta/main.yaml
+++ b/provisioning/ansible/roles/git-environment/meta/main.yaml
@@ -1,0 +1,4 @@
+---
+dependencies:
+- role: bash-environment
+- role: git

--- a/provisioning/ansible/roles/git-environment/tasks/main.yaml
+++ b/provisioning/ansible/roles/git-environment/tasks/main.yaml
@@ -1,0 +1,22 @@
+---
+- name: Installing ...
+  copy:
+    src: .bashrc.d/git-vars.sh
+    dest: ~/.bashrc.d/git-vars.sh
+    mode: u+x
+- name: Checking if ~/.gitconfig exists ...
+  stat: path=~/.gitconfig
+  register: gitconfig
+- name: Creating ~/.gitconfig ...
+  shell: ~/bin/create-gitconfig.sh "{{ git_user_name }}" "{{ git_user_email }}"
+  when: (gitconfig.stat.exists == False)
+- name: Setting global user name ...
+  git_config:
+    name: user.name
+    scope: global
+    value: "{{ git_user_name }}"
+- name: Setting global user email ...
+  git_config:
+    name: user.email
+    scope: global
+    value: "{{ git_user_email }}"

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,3 @@
+GIT_USER_EMAIL='user@email.com'
+GIT_USER_NAME='Git User'
+GIT_SSH_PRIVATE_KEY_FILE='\native\os\path\to\the\private\ssh\key'


### PR DESCRIPTION
Added Git configuration from host

- On the host, the Git configuration is specified in an .env file. A sample .env file is provided.
- On the VM, the Git configuration is saved in /etc/provisioning/.
- On the VM, for the Vagrant user, the .gitconfig file is created and the GIT_SSH_COMMAND is set and exported.
